### PR TITLE
Modify the handling of the {Name} variable so that Playnite can correctly locate folders when it contains illegal characters and spaces (remove illegal characters, do not handle spaces).

### DIFF
--- a/source/Services/SsvPathResolver.cs
+++ b/source/Services/SsvPathResolver.cs
@@ -4,6 +4,8 @@ using Playnite.SDK;
 using Playnite.SDK.Models;
 using ScreenshotsVisualizer.Models;
 using System.Text;
+using System.IO;
+using System.Text.RegularExpressions;
 
 namespace ScreenshotsVisualizer.Services
 {
@@ -13,6 +15,41 @@ namespace ScreenshotsVisualizer.Services
     /// </summary>
     public class SsvPathResolver
     {
+        private static readonly ILogger _logger = LogManager.GetLogger();
+
+        /// Remove only illegal characters, do not compress spaces.
+        private static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return "Unnamed";
+
+            var invalid = Path.GetInvalidFileNameChars();
+            var result = string.Concat(name.Split(invalid)).Trim();
+
+            return string.IsNullOrWhiteSpace(result) ? "Unnamed" : result;
+        }
+
+        private static string GetSafePathPreserveSpaces(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return path;
+
+            try
+            {
+                char[] invalidPathChars = Path.GetInvalidPathChars();
+                foreach (char c in invalidPathChars)
+                {
+                    path = path.Replace(c.ToString(), "");
+                }
+
+                return Path.GetFullPath(path);
+            }
+            catch
+            {
+                return path;
+            }
+        }
+
         /// <summary>
         /// Resolves the configured screenshot folder path for a game.
         /// </summary>
@@ -26,8 +63,28 @@ namespace ScreenshotsVisualizer.Services
                 return string.Empty;
             }
 
-            string pathFolder = PlayniteTools.StringExpandWithStores(game, folderSettings.ScreenshotsFolder);
-            return PathValidator.GetSafePath(pathFolder, false);
+            string originalPath = folderSettings.ScreenshotsFolder;
+            string originalGameName = game.Name;
+            string sanitizedGameName = SanitizeFileName(originalGameName);
+
+            _logger.Debug($"[SsvPathResolver] ResolvePath START:");
+            _logger.Debug($"  ├─ Original game name: '{originalGameName}'");
+            _logger.Debug($"  ├─ Sanitized game name: '{sanitizedGameName}'");
+            _logger.Debug($"  ├─ Original folder pattern: '{originalPath}'");
+
+            // First, manually replace {Name} with the cleaned-up name.
+            string pathAfterNameReplace = originalPath.Replace("{Name}", sanitizedGameName);
+            _logger.Debug($"  ├─ After {{Name}} replace: '{pathAfterNameReplace}'");
+
+            // Then, let PlayniteTools expand the other variables.
+            string expandedPath = PlayniteTools.StringExpandWithStores(game, pathAfterNameReplace);
+            _logger.Debug($"  ├─ After StringExpandWithStores: '{expandedPath}'");
+
+            // Clean up using a custom path (keep spaces, do not compress).
+            string safePath = GetSafePathPreserveSpaces(expandedPath);
+            _logger.Debug($"  └─ Final safe path: '{safePath}'");
+
+            return safePath;
         }
 
         /// <summary>
@@ -43,17 +100,45 @@ namespace ScreenshotsVisualizer.Services
                 return string.Empty;
             }
 
-            string pattern = PlayniteTools.StringExpandWithStores(game, folderSettings.FilePattern);
-            pattern = EscapeRegexSpecialChars(pattern);
-            pattern = pattern.Replace("\\*", ".*");
-            pattern = pattern.Replace("\\{digit\\}", @"\d+");
-            pattern = pattern.Replace("\\{DateModified\\}", @"[0-9]{4}[-_][0-9]{2}[-_][0-9]{2}");
-            pattern = pattern.Replace("\\{DateTimeModified\\}", @"[0-9]{4}[-_][0-9]{2}[-_][0-9]{2}[ -_][0-9]{2}[-_][0-9]{2}[-_][0-9]{2}");
+            string originalPattern = folderSettings.FilePattern;
+            string originalGameName = game.Name;
+            string sanitizedGameName = SanitizeFileName(originalGameName);
 
-            string gameName = API.Instance.ExpandGameVariables(game, "{Name}");
-            string safeGameNamePattern = PathValidator.GetSafePathName(gameName).Replace(" ", "[ ]*");
-            pattern = pattern.Replace(gameName, safeGameNamePattern);
-            return "^" + pattern + "$";
+            _logger.Debug($"[SsvPathResolver] ResolveFilePatternRegex START:");
+            _logger.Debug($"  ├─ Original game name: '{originalGameName}'");
+            _logger.Debug($"  ├─ Sanitized game name: '{sanitizedGameName}'");
+            _logger.Debug($"  ├─ Original file pattern: '{originalPattern}'");
+
+            // First, replace {Name} with the cleaned-up name.
+            string patternAfterNameReplace = originalPattern.Replace("{Name}", sanitizedGameName);
+            _logger.Debug($"  ├─ After {{Name}} replace: '{patternAfterNameReplace}'");
+
+            // Then let PlayniteTools expand the other variables.
+            string expandedPattern = PlayniteTools.StringExpandWithStores(game, patternAfterNameReplace);
+            _logger.Debug($"  ├─ After StringExpandWithStores: '{expandedPattern}'");
+
+            string escapedPattern = EscapeRegexSpecialChars(expandedPattern);
+            _logger.Debug($"  ├─ After EscapeRegexSpecialChars: '{escapedPattern}'");
+
+            string patternWithWildcards = escapedPattern
+                .Replace("\\*", ".*")
+                .Replace("\\{digit\\}", @"\d+")
+                .Replace("\\{DateModified\\}", @"[0-9]{4}[-_][0-9]{2}[-_][0-9]{2}")
+                .Replace("\\{DateTimeModified\\}", @"[0-9]{4}[-_][0-9]{2}[-_][0-9]{2}[ -_][0-9]{2}[-_][0-9]{2}[-_][0-9]{2}");
+            _logger.Debug($"  ├─ After wildcard replacements: '{patternWithWildcards}'");
+
+            string gameNameForRegex = sanitizedGameName;
+            // Replace each space with [ ]* (matches any number of spaces)
+            string safeGameNamePattern = Regex.Escape(gameNameForRegex).Replace("\\ ", "[ ]*");
+            _logger.Debug($"  ├─ Game name regex: '{safeGameNamePattern}' (from '{gameNameForRegex}')");
+
+            string finalPattern = patternWithWildcards.Replace(Regex.Escape(gameNameForRegex), safeGameNamePattern);
+            _logger.Debug($"  ├─ After game name regex replace: '{finalPattern}'");
+
+            string anchoredPattern = "^" + finalPattern + "$";
+            _logger.Debug($"  └─ Final anchored regex: '{anchoredPattern}'");
+
+            return anchoredPattern;
         }
 
         private static string EscapeRegexSpecialChars(string input)


### PR DESCRIPTION
Modify the handling of the {Name} variable so that Playnite can correctly locate folders when it contains illegal characters and spaces (remove illegal characters, do not handle spaces).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved game path and file pattern resolution for titles containing spaces or characters that are invalid in file names.
  - File matching is now more reliable when game names include multiple or irregular spaces.
  - Preserved spaces in generated paths and patterns to better reflect actual game folder and file names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->